### PR TITLE
修复可能在linux出现的sqlite3版本不适配问题。

### DIFF
--- a/ChatHaruhi/ChromaDB.py
+++ b/ChatHaruhi/ChromaDB.py
@@ -1,3 +1,6 @@
+__import__('pysqlite3')
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 import chromadb
 from .BaseDB import BaseDB
 import random


### PR DESCRIPTION
在Debian10和Ubuntu 20.04.6 LTS调用Haruhi库时均得到以下报错：

```
Traceback
from .ChatHaruhi import ChatHaruhi
File "/root/needy/ChatHaruhi/ChatHaruhi.py", line 1, in 
from .ChromaDB import ChromaDB
File "/root/needy/ChatHaruhi/ChromaDB.py", line 2, in 
import chromadb
File "/usr/local/lib/python3.8/dist-packages/chromadb/__init__.py", line 78, in 
raise RuntimeError(
RuntimeError: Your system has an unsupported version of sqlite3. Chroma                     requires sqlite3 >= 3.35.0.
Please visit                     https://docs.trychroma.com/troubleshooting#sqlite to learn how                     to upgrade.
```
原因是部分Linux较旧的分发版内置的sqlite3小于项目所需版本。

安装`pysqlite-binary`后即可让项目调用该库自带的pysqlite3。